### PR TITLE
Add round streak stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project defines a significantly enhanced client-side web application for tr
 
 Persistence between sessions relies on **manual CSV export/import**, now featuring **more robust validation** on import and a UI note recommending backups. The application includes user **confirmation dialogues** to prevent accidental data loss.
 
-A major feature is the **integrated, toggleable statistics section** which is now significantly expanded. It displays overall, per-session/day, and detailed per-game statistics (including **round-by-round scores with the round winner highlighted**). New statistics include **win streaks, highest/lowest scoring rounds, and player head-to-head records**. Basic **filtering by date and player** is implemented for the statistics view, complemented by a **bar chart visualizing total wins**.
+A major feature is the **integrated, toggleable statistics section** which is now significantly expanded. It displays overall, per-session/day, and detailed per-game statistics (including **round-by-round scores with the round winner highlighted**). New statistics include **win streaks, longest streaks of individual hand wins, highest/lowest scoring rounds**, and player head-to-head records. Basic **filtering by date and player** is implemented for the statistics view, complemented by a **bar chart visualizing total wins**.
 
 The UI incorporates **basic animations** for feedback and is designed with **CSS responsiveness** for better usability across different screen sizes. The application runs entirely within the user's web browser using HTML, CSS, and JavaScript, requiring no server-side backend.
 
@@ -31,7 +31,7 @@ The UI incorporates **basic animations** for feedback and is designed with **CSS
     * Toggleable section within the main page.
     * **Calculated from currently loaded/played data.**
     * **Filtering:** Basic filtering by date range and selected players.
-    * **Overall Stats:** Total games, wins/player (list & bar chart), max win streaks, highest/lowest scoring rounds (details), head-to-head win/loss records between players.
+    * **Overall Stats:** Total games, wins/player (list & bar chart), max win streaks, counts of \*hand win streaks\* (\u22654), highest/lowest scoring rounds (details), and head-to-head win/loss records between players.
     * **Session/Day Stats:** Groups completed games by date, showing games played and winner(s) of the day.
     * **Per-Game Stats:** Detailed view including final scores and a table of **round-by-round scores showing who went out each round.**
 * **UI Feedback & Responsiveness:**

--- a/index.html
+++ b/index.html
@@ -111,8 +111,13 @@
                          <ul id="wins-per-player"></ul>
                      </div>
                      <div>
-                         <h4>Voittoputket (max):</h4>
+                         <h4>Voittoputket (max pelit):</h4>
                          <ul id="win-streaks"></ul>
+                     </div>
+                     <div>
+                         <h4>Kierrosvoittoputket (\u22654):</h4>
+                         <ul id="round-win-streaks"></ul>
+                         <p id="longest-round-streak-info"></p>
                      </div>
                  </div>
                   <div class="stats-columns">

--- a/script.js
+++ b/script.js
@@ -51,6 +51,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const perGameStatsDisplay = document.getElementById('per-game-stats');
     const winsPerPlayerList = document.getElementById('wins-per-player');
     const winStreaksList = document.getElementById('win-streaks');
+    const roundWinStreaksList = document.getElementById('round-win-streaks');
+    const longestRoundStreakInfo = document.getElementById('longest-round-streak-info');
     const headToHeadStatsDiv = document.getElementById('head-to-head-stats');
     const hiloRoundsStatsList = document.getElementById('hilo-rounds-stats');
     const sessionsListDiv = document.getElementById('sessions-list');
@@ -703,8 +705,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     if(player){
                          playerScores[player] += score;
                          playerRoundsPlayed[player]++;
-                         // Check Hi/Lo (only if score is not 0?) - Let's count 0 too.
-                         if (score < bestRound.score) bestRound = { score, player, game: game.gameNumber, round: roundIndex + 1};
+                         // Check Hi/Lo (ignore 0 for best round)
+                         if (score > 0 && score < bestRound.score) bestRound = { score, player, game: game.gameNumber, round: roundIndex + 1};
                          if (score > worstRound.score) worstRound = { score, player, game: game.gameNumber, round: roundIndex + 1};
                     }
                 });
@@ -723,9 +725,22 @@ document.addEventListener('DOMContentLoaded', () => {
          // Win Streaks
         const streaks = calculateWinStreaks(games);
         winStreaksList.innerHTML = '';
-         sortedPlayersByWins.forEach(player => { // Sort by wins for consistency
+         sortedPlayersByWins.forEach(player => {
              winStreaksList.innerHTML += `<li>${player}: ${streaks[player] || 0}</li>`;
          });
+
+        const roundStreakData = calculateRoundWinStreaks(games, 4);
+        roundWinStreaksList.innerHTML = '';
+         sortedPlayersByWins.forEach(player => {
+             const count = roundStreakData.streakCounts[player] || 0;
+             const maxLen = roundStreakData.maxStreaks[player] || 0;
+             roundWinStreaksList.innerHTML += `<li>${player}: ${count} kpl (max ${maxLen})</li>`;
+         });
+        if (roundStreakData.global.player) {
+             longestRoundStreakInfo.textContent = `Pisin kierrosputki: ${roundStreakData.global.player} ${roundStreakData.global.length}`;
+        } else {
+             longestRoundStreakInfo.textContent = '';
+        }
 
 
         // Head-to-Head
@@ -911,9 +926,9 @@ document.addEventListener('DOMContentLoaded', () => {
                      const player = game.players[playerIndex];
                      const detail = `${score}p (${player}, P${game.gameNumber} K${roundIndex + 1})`;
 
-                     if (score < bestRound.score) {
+                     if (score > 0 && score < bestRound.score) {
                          bestRound = { score: score, details: [detail] };
-                     } else if (score === bestRound.score) {
+                     } else if (score > 0 && score === bestRound.score) {
                          bestRound.details.push(detail);
                      }
 
@@ -931,6 +946,54 @@ document.addEventListener('DOMContentLoaded', () => {
         if(worstRound.details.length > maxDetails) worstRound.details = worstRound.details.slice(0, maxDetails).concat(`...ja ${worstRound.details.length - maxDetails} muuta`);
 
         return { bestRound, worstRound };
+    }
+
+    function calculateRoundWinStreaks(games, threshold = 4) {
+        const currentStreaks = {};
+        const maxStreaks = {};
+        const streakCounts = {};
+        let globalPlayer = null;
+        let globalLength = 0;
+
+        const sortedGames = [...games].sort((a,b) => a.gameNumber - b.gameNumber);
+
+        sortedGames.forEach(game => {
+            if (!game.players || !game.roundWinners) return;
+
+            game.roundWinners.forEach(winnerIdx => {
+                game.players.forEach((p, i) => {
+                    if (!currentStreaks[p]) currentStreaks[p] = 0;
+                    if (!maxStreaks[p]) maxStreaks[p] = 0;
+                    if (!streakCounts[p]) streakCounts[p] = 0;
+                });
+
+                if (winnerIdx !== undefined && winnerIdx >= 0 && game.players[winnerIdx]) {
+                    const winner = game.players[winnerIdx];
+                    currentStreaks[winner]++;
+
+                    game.players.forEach((p, idx) => {
+                        if (idx !== winnerIdx) currentStreaks[p] = 0;
+                    });
+
+                    if (currentStreaks[winner] > maxStreaks[winner]) {
+                        maxStreaks[winner] = currentStreaks[winner];
+                    }
+
+                    if (currentStreaks[winner] === threshold) {
+                        streakCounts[winner]++;
+                    }
+
+                    if (currentStreaks[winner] > globalLength) {
+                        globalLength = currentStreaks[winner];
+                        globalPlayer = winner;
+                    }
+                } else {
+                    Object.keys(currentStreaks).forEach(p => currentStreaks[p] = 0);
+                }
+            });
+        });
+
+        return { maxStreaks, streakCounts, global: { player: globalPlayer, length: globalLength } };
     }
 
 


### PR DESCRIPTION
## Summary
- track win streaks for individual rounds and display them
- ignore zero scores when reporting lowest round
- document hand win streaks in README

## Testing
- `npm test` *(fails: Could not find package.json)*