### PR TITLE
Fix stats heading symbol

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
                          <ul id="win-streaks"></ul>
                      </div>
                      <div>
-                         <h4>Kierrosvoittoputket (\u22654):</h4>
+                         <h4>Kierrosvoittoputket (&ge;4):</h4>
                          <ul id="round-win-streaks"></ul>
                          <p id="longest-round-streak-info"></p>
                      </div>


### PR DESCRIPTION
## Summary
- fix the stats heading in `index.html` to show the ≥4 symbol correctly

## Testing
- `grep -n Kierrosvoittoputket -n index.html`