### PR TITLE
Configure Vite for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,17 @@ npm test
 npm run lint
 ```
 
+## Deployment on GitHub Pages
+
+1. Set the `base` path in `vite.config.js` to your repository name (already
+   configured as `/Uno-Game-Tracker/`).
+2. Build the project:
+   ```bash
+   npm run build
+   ```
+3. Deploy the generated `dist/` directory to GitHub Pages (e.g. using the
+   `gh-pages` branch or a GitHub Actions workflow).
+
+Opening `index.html` directly from disk will not load the React code; it must be
+served from the built files or via the Vite dev server.
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Set base path for GitHub Pages deployment
+  // Replace with your repo name if different
+  base: '/Uno-Game-Tracker/',
 });


### PR DESCRIPTION
## Summary
- set the Vite `base` path so built assets load correctly on GitHub Pages
- document the build/deploy steps for GitHub Pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*