### PR TITLE
Fix totals update in addRound

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,8 +76,9 @@ function Game({ players, onReset }) {
     if (scores.some(v => isNaN(v) || v < 0)) return alert('Pisteiden on oltava numeroita');
     setRounds([...rounds, scores]);
     setInputs(players.map(() => ''));
-    const totals = totalsHistory[totalsHistory.length - 1];
-    if (totals.some(t => t >= SCORE_LIMIT)) setIsOver(true);
+    const newTotals = totalsHistory[totalsHistory.length - 1]
+      .map((t, i) => t + scores[i]);
+    if (newTotals.some(t => t >= SCORE_LIMIT)) setIsOver(true);
   };
 
   const downloadCsv = () => {


### PR DESCRIPTION
## Summary
- fix game over logic to check totals after adding the current round

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*