### PR TITLE
Handle WentOutIndex column on import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -177,10 +177,11 @@ export default function App() {
     const file = e.target.files[0];
     if (!file) return;
     const reader = new FileReader();
-    reader.onload = evt => {
-      const lines = evt.target.result.trim().split(/\r?\n/);
-      const [, ...playerNames] = lines[0].split(',');
-      setPlayers(playerNames);
+      reader.onload = evt => {
+        const lines = evt.target.result.trim().split(/\r?\n/);
+        const [, ...headers] = lines[0].split(',').map(h => h.trim());
+        const playerNames = headers.filter(h => h !== 'WentOutIndex');
+        setPlayers(playerNames);
     };
     reader.readAsText(file);
   };


### PR DESCRIPTION
## Summary
- clean up import logic for CSV files
- trim header names and ignore the `WentOutIndex` column when detecting players

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: eslint-plugin-react missing)*