### PR TITLE
Fix score validation, imports, and statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Detailed Statistics: View comprehensive stats, including total wins, head-to-hea
 Responsive Design: The interface is fully responsive and works great on desktops, tablets, and mobile phones.
 
 How to Use
-Download the uno-score-tracker.html file.
+Download the index.html file.
 
 Open the file in any modern web browser (like Chrome, Firefox, Safari, or Edge).
+
+An internet connection is required for the Tailwind CSS and Chart.js CDN resources. Core scorekeeping remains available if Chart.js cannot be loaded, but charts are hidden.
 
 Add player names.
 
@@ -45,6 +47,13 @@ Tailwind CSS: For a modern, utility-first styling approach.
 JavaScript: For all the game logic, state management, and interactivity.
 
 Chart.js: For rendering the score progression and statistics charts.
+
+Development Checks
+
+Install the development dependencies and run the HTML validation and DOM integration tests:
+
+    npm install
+    npm run check
 
 ​
 
@@ -126,6 +135,8 @@ Data & History Rules
 
         Head-to-head records track wins/losses between specific players
 
+        Co-winners in a tied game are not counted as winning against each other
+
         Filters apply to displayed stats but not all-time records
 
 UI/UX Rules
@@ -205,4 +216,3 @@ Player Reordering Details
         Purpose: Arrange players in physical seating order for easier gameplay
 
         Impact: Player order determines clockwise dealer rotation
-

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Uno Score Tracker</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -51,7 +51,7 @@
         .drag-handle:active { cursor: grabbing; }
         .player-item.dragging { opacity: 0.5; }
         .player-item.drag-over-target { border-top: 2px solid #4f46e5; }
-        
+
         /* Dark Mode Styles */
         .dark body { background-color: #111827; }
         .dark .winner-highlight { background-color: #166534 !important; color: #dcfce7 !important; }
@@ -60,8 +60,10 @@
     </style>
     <script>
         // Tailwind dark mode plugin configuration
-        tailwind.config = {
-            darkMode: 'class',
+        if (window.tailwind) {
+            window.tailwind.config = {
+                darkMode: 'class',
+            };
         }
     </script>
 </head>
@@ -76,9 +78,9 @@
             </div>
             <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white">Uno Score Tracker</h1>
             <p class="text-gray-600 dark:text-gray-400 mt-2">A modern way to keep track of your Uno games.</p>
-            
+
              <!-- Theme Toggle Button -->
-            <button id="theme-toggle" class="absolute top-0 right-0 p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900">
+            <button id="theme-toggle" type="button" aria-label="Switch to dark mode" aria-pressed="false" class="absolute top-0 right-0 p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900">
                 <svg id="theme-toggle-dark-icon" class="h-6 w-6 hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
                 <svg id="theme-toggle-light-icon" class="h-6 w-6 hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 14.95a1 1 0 010-1.414l.707-.707a1 1 0 011.414 1.414l-.707.707a1 1 0 01-1.414 0zM3 11a1 1 0 100-2H2a1 1 0 100 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path></svg>
             </button>
@@ -86,7 +88,7 @@
 
         <!-- Main Grid -->
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            
+
             <!-- Left Column: Setup & Controls -->
             <div class="lg:col-span-1 space-y-6">
                 <!-- Player Setup -->
@@ -95,8 +97,9 @@
                     <div id="player-list" class="space-y-2 mb-4"></div>
                     <p class="text-xs text-gray-500 dark:text-gray-400 text-center -mt-2 mb-4">You can reorder players by dragging.</p>
                     <div class="flex space-x-2">
-                        <input type="text" id="new-player-name" placeholder="Enter player name" class="flex-grow p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400">
-                        <button id="add-player-btn" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition duration-200 shadow">Add</button>
+                        <label for="new-player-name" class="sr-only">Player name</label>
+                        <input type="text" id="new-player-name" maxlength="50" autocomplete="off" placeholder="Enter player name" class="flex-grow p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400">
+                        <button id="add-player-btn" type="button" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition duration-200 shadow">Add</button>
                     </div>
                 </div>
 
@@ -104,22 +107,22 @@
                 <div class="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-md">
                     <h2 class="text-2xl font-semibold mb-4 border-b pb-2 dark:border-gray-600">Game Controls</h2>
                     <div class="grid grid-cols-1 gap-4">
-                        <button id="new-game-btn" class="w-full bg-green-600 text-white px-4 py-3 rounded-lg hover:bg-green-700 transition duration-200 shadow font-semibold disabled:bg-gray-400 disabled:dark:bg-gray-600 flex items-center justify-center gap-2" disabled>
+                        <button id="new-game-btn" type="button" class="w-full bg-green-600 text-white px-4 py-3 rounded-lg hover:bg-green-700 transition duration-200 shadow font-semibold disabled:bg-gray-400 disabled:dark:bg-gray-600 flex items-center justify-center gap-2" disabled>
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd" /></svg>
                             <span>Start New Game</span>
                         </button>
-                        <button id="toggle-stats-btn" class="w-full bg-indigo-600 text-white px-4 py-3 rounded-lg hover:bg-indigo-700 transition duration-200 shadow font-semibold flex items-center justify-center gap-2">
+                        <button id="toggle-stats-btn" type="button" class="w-full bg-indigo-600 text-white px-4 py-3 rounded-lg hover:bg-indigo-700 transition duration-200 shadow font-semibold flex items-center justify-center gap-2">
                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0h2a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm10 0V5a2 2 0 00-2-2h-2a2 2 0 00-2 2v14a2 2 0 002 2h2a2 2 0 002-2z" /></svg>
                             <span>Show Statistics</span>
                         </button>
                     </div>
                 </div>
-                
+
                 <!-- Data Management -->
                 <div class="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-md">
                     <h2 class="text-2xl font-semibold mb-4 border-b pb-2 dark:border-gray-600">Data Management</h2>
                      <div class="space-y-4">
-                        <button id="export-data-btn" class="w-full bg-gray-700 text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition duration-200 disabled:bg-gray-400 disabled:dark:bg-gray-600 flex items-center justify-center gap-2">
+                        <button id="export-data-btn" type="button" class="w-full bg-gray-700 text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition duration-200 disabled:bg-gray-400 disabled:dark:bg-gray-600 flex items-center justify-center gap-2">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
                             <span>Export Data (JSON)</span>
                         </button>
@@ -141,7 +144,7 @@
                     <h2 class="text-3xl font-bold mb-1 text-center">Current Game</h2>
                     <div id="game-status" class="text-center text-gray-600 dark:text-gray-400 mb-4">Round <span id="round-number">1</span>. Current Dealer: <span id="current-dealer-name" class="font-bold">N/A</span></div>
                     <div id="scoreboard" class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center"></div>
-                     <div class="mt-6">
+                     <div id="score-progression-chart-container" class="mt-6">
                          <canvas id="score-progression-chart"></canvas>
                      </div>
                 </div>
@@ -150,55 +153,55 @@
                     <h3 class="text-2xl font-semibold mb-4 text-center">Enter Round Scores</h3>
                     <div id="score-entry" class="grid grid-cols-2 md:grid-cols-4 gap-4 items-center"></div>
                     <div id="round-controls" class="mt-6 flex justify-center items-center gap-4">
-                        <button id="undo-round-btn" class="bg-yellow-500 text-white px-6 py-3 rounded-lg hover:bg-yellow-600 transition duration-200 shadow-lg font-semibold disabled:bg-gray-400 disabled:dark:bg-gray-600 flex items-center justify-center gap-2">
+                        <button id="undo-round-btn" type="button" class="bg-yellow-500 text-white px-6 py-3 rounded-lg hover:bg-yellow-600 transition duration-200 shadow-lg font-semibold disabled:bg-gray-400 disabled:dark:bg-gray-600 flex items-center justify-center gap-2">
                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 10h10a8 8 0 01-16 0l-1.5-1.5M21 14H11a8 8 0 00-16 0l1.5 1.5" /></svg>
                             <span>Undo Last Round</span>
                         </button>
-                        <button id="add-round-btn" class="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition duration-200 shadow-lg text-lg font-semibold flex items-center justify-center gap-2">
+                        <button id="add-round-btn" type="button" class="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition duration-200 shadow-lg text-lg font-semibold flex items-center justify-center gap-2">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
                             <span>Submit Round</span>
                         </button>
                     </div>
-                    <p id="score-entry-error" class="text-red-500 text-center mt-4 h-5"></p>
+                    <p id="score-entry-error" role="alert" aria-live="polite" class="text-red-500 text-center mt-4 h-5"></p>
                 </div>
             </div>
         </div>
-        
+
         <!-- Statistics Section -->
         <div id="statistics-section" class="mt-8 hidden bg-white dark:bg-gray-800 p-6 rounded-xl shadow-lg"></div>
 
     </div>
 
     <!-- Modals -->
-    <div id="info-modal" class="modal-backdrop">
-        <div class="modal-content text-center bg-white dark:bg-gray-800">
+    <div id="info-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-hidden="true" aria-describedby="info-modal-message" inert>
+        <div class="modal-content text-center bg-white dark:bg-gray-800" tabindex="-1">
             <p id="info-modal-message" class="mb-6 text-lg"></p>
-            <button id="info-modal-ok-btn" class="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition">OK</button>
+            <button id="info-modal-ok-btn" type="button" class="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition">OK</button>
         </div>
     </div>
 
-    <div id="confirmation-modal" class="modal-backdrop">
-        <div class="modal-content bg-white dark:bg-gray-800">
+    <div id="confirmation-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="modal-title" aria-describedby="modal-message" inert>
+        <div class="modal-content bg-white dark:bg-gray-800" tabindex="-1">
             <h3 id="modal-title" class="text-xl font-bold mb-4">Confirmation</h3>
             <p id="modal-message" class="mb-6"></p>
             <div class="flex justify-end space-x-3">
-                <button id="modal-cancel-btn" class="bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-gray-200 px-4 py-2 rounded-lg hover:bg-gray-400 dark:hover:bg-gray-500 transition">Cancel</button>
-                <button id="modal-confirm-btn" class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition">Confirm</button>
+                <button id="modal-cancel-btn" type="button" class="bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-gray-200 px-4 py-2 rounded-lg hover:bg-gray-400 dark:hover:bg-gray-500 transition">Cancel</button>
+                <button id="modal-confirm-btn" type="button" class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition">Confirm</button>
             </div>
         </div>
     </div>
 
-    <div id="winner-selection-modal" class="modal-backdrop">
-        <div class="modal-content bg-white dark:bg-gray-800">
-            <h3 class="text-xl font-bold mb-4">Select Round Winner</h3>
+    <div id="winner-selection-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="winner-selection-title" inert>
+        <div class="modal-content bg-white dark:bg-gray-800" tabindex="-1">
+            <h3 id="winner-selection-title" class="text-xl font-bold mb-4">Select Round Winner</h3>
             <p class="mb-6">Multiple players scored 0. Please select the player who went out.</p>
             <div id="winner-options" class="space-y-2"></div>
         </div>
     </div>
 
-    <div id="dealer-selection-modal" class="modal-backdrop">
-        <div class="modal-content bg-white dark:bg-gray-800">
-            <h3 class="text-xl font-bold mb-4">Select Starting Dealer</h3>
+    <div id="dealer-selection-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="dealer-selection-title" inert>
+        <div class="modal-content bg-white dark:bg-gray-800" tabindex="-1">
+            <h3 id="dealer-selection-title" class="text-xl font-bold mb-4">Select Starting Dealer</h3>
             <p class="mb-6">Who is dealing the first round?</p>
             <div id="dealer-options" class="space-y-2"></div>
         </div>
@@ -207,11 +210,22 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             // STATE
-            let state = {
+            const STORAGE_KEY = 'unoTrackerState';
+            const INVALID_STORAGE_BACKUP_KEY = 'unoTrackerStateInvalidBackup';
+            const SCHEMA_VERSION = 1;
+            const MAX_PLAYER_NAME_LENGTH = 50;
+
+            const createEmptyState = () => ({
+                schemaVersion: SCHEMA_VERSION,
                 players: [],
-                games: [], 
+                games: [],
                 currentGame: null,
-            };
+            });
+
+            const createDictionary = () => Object.create(null);
+
+            let state = createEmptyState();
+            let statsFilters = { player: 'all', date: '' };
 
             // DOM ELEMENTS
             const playerListEl = document.getElementById('player-list');
@@ -232,11 +246,11 @@
             const importDataInput = document.getElementById('import-data-input');
             const toggleStatsBtn = document.getElementById('toggle-stats-btn');
             const statsSectionEl = document.getElementById('statistics-section');
-            
+
             // Chart instances
             let winsBarChart = null;
             let scoreProgressionChart = null;
-            
+
             // --- THEME TOGGLE LOGIC ---
             const themeToggleBtn = document.getElementById('theme-toggle');
             const darkIcon = document.getElementById('theme-toggle-dark-icon');
@@ -253,7 +267,13 @@
                     darkIcon.classList.add('hidden');
                     lightIcon.classList.remove('hidden');
                 }
-                localStorage.setItem('theme', theme);
+                try {
+                    localStorage.setItem('theme', theme);
+                } catch (error) {
+                    console.error('Unable to save theme preference:', error);
+                }
+                themeToggleBtn.setAttribute('aria-pressed', String(theme === 'dark'));
+                themeToggleBtn.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
 
                 // Re-render charts with correct colors
                 if (state.currentGame) updateScoreProgressionChart();
@@ -266,6 +286,159 @@
 
             // --- SECURITY HELPER ---
             const escape = s => String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+
+            function isValidScore(value) {
+                return Number.isSafeInteger(value) && value >= 0;
+            }
+
+            function normalizePlayerNames(value, fieldName = 'players', minimumPlayers = 2) {
+                if (!Array.isArray(value) || value.length < minimumPlayers) {
+                    throw new Error(`Invalid ${fieldName}: at least ${minimumPlayers} player${minimumPlayers === 1 ? '' : 's'} are required.`);
+                }
+
+                const names = value.map((name, index) => {
+                    if (typeof name !== 'string') {
+                        throw new Error(`Invalid ${fieldName}[${index}]: player name must be text.`);
+                    }
+                    const normalizedName = name.trim();
+                    if (!normalizedName || normalizedName.length > MAX_PLAYER_NAME_LENGTH) {
+                        throw new Error(`Invalid ${fieldName}[${index}]: player name must be 1-${MAX_PLAYER_NAME_LENGTH} characters.`);
+                    }
+                    return normalizedName;
+                });
+
+                const normalizedKeys = names.map(name => name.toLocaleLowerCase());
+                if (new Set(normalizedKeys).size !== names.length) {
+                    throw new Error(`Invalid ${fieldName}: duplicate player names are not allowed.`);
+                }
+                return names;
+            }
+
+            function normalizeRound(rawRound, playerNames, fieldName) {
+                if (!rawRound || typeof rawRound !== 'object' || Array.isArray(rawRound)) {
+                    throw new Error(`Invalid ${fieldName}: round must be an object.`);
+                }
+                if (!playerNames.includes(rawRound.winner)) {
+                    throw new Error(`Invalid ${fieldName}: winner is not one of the players.`);
+                }
+                if (!rawRound.scores || typeof rawRound.scores !== 'object' || Array.isArray(rawRound.scores)) {
+                    throw new Error(`Invalid ${fieldName}: scores must be an object.`);
+                }
+
+                const scores = createDictionary();
+                playerNames.forEach(playerName => {
+                    if (!Object.prototype.hasOwnProperty.call(rawRound.scores, playerName)) {
+                        throw new Error(`Invalid ${fieldName}: score for ${playerName} is missing.`);
+                    }
+                    const score = rawRound.scores[playerName];
+                    if (!isValidScore(score)) {
+                        throw new Error(`Invalid ${fieldName}: score for ${playerName} must be a non-negative whole number.`);
+                    }
+                    scores[playerName] = score;
+                });
+
+                if (scores[rawRound.winner] !== 0) {
+                    throw new Error(`Invalid ${fieldName}: the round winner must have zero points.`);
+                }
+                return { winner: rawRound.winner, scores };
+            }
+
+            function calculateScoresAndHistory(playerNames, rounds) {
+                const totals = createDictionary();
+                const histories = createDictionary();
+                playerNames.forEach(name => {
+                    totals[name] = 0;
+                    histories[name] = [0];
+                });
+                rounds.forEach(round => {
+                    playerNames.forEach(name => {
+                        totals[name] += round.scores[name];
+                        histories[name].push(totals[name]);
+                    });
+                });
+                return { totals, histories };
+            }
+
+            function normalizeCompletedGame(rawGame, gameIndex) {
+                if (!rawGame || typeof rawGame !== 'object' || Array.isArray(rawGame)) {
+                    throw new Error(`Invalid games[${gameIndex}]: game must be an object.`);
+                }
+                const players = normalizePlayerNames(rawGame.players, `games[${gameIndex}].players`);
+                if (!Array.isArray(rawGame.rounds) || rawGame.rounds.length === 0) {
+                    throw new Error(`Invalid games[${gameIndex}].rounds: at least one round is required.`);
+                }
+                const rounds = rawGame.rounds.map((round, roundIndex) =>
+                    normalizeRound(round, players, `games[${gameIndex}].rounds[${roundIndex}]`)
+                );
+                const parsedDate = new Date(rawGame.date);
+                if (typeof rawGame.date !== 'string' || Number.isNaN(parsedDate.getTime())) {
+                    throw new Error(`Invalid games[${gameIndex}].date.`);
+                }
+
+                const { totals } = calculateScoresAndHistory(players, rounds);
+                const minimumScore = Math.min(...players.map(name => totals[name]));
+                const winners = players.filter(name => totals[name] === minimumScore);
+                const finalScores = players.map(name => ({ name, score: totals[name] }));
+
+                return {
+                    date: parsedDate.toISOString(),
+                    players,
+                    winners,
+                    finalScores,
+                    rounds,
+                };
+            }
+
+            function normalizeCurrentGame(rawGame, statePlayers) {
+                if (rawGame === null || rawGame === undefined) return null;
+                if (!rawGame || typeof rawGame !== 'object' || Array.isArray(rawGame) || !Array.isArray(rawGame.players)) {
+                    throw new Error('Invalid currentGame.');
+                }
+
+                const playerNames = normalizePlayerNames(
+                    rawGame.players.map(player => player && player.name),
+                    'currentGame.players'
+                );
+                if (playerNames.length !== statePlayers.length || playerNames.some((name, index) => name !== statePlayers[index])) {
+                    throw new Error('Invalid currentGame: active players must match the player list.');
+                }
+                if (!Array.isArray(rawGame.rounds)) {
+                    throw new Error('Invalid currentGame.rounds.');
+                }
+                const rounds = rawGame.rounds.map((round, roundIndex) =>
+                    normalizeRound(round, playerNames, `currentGame.rounds[${roundIndex}]`)
+                );
+                if (!Number.isSafeInteger(rawGame.dealerIndex) || rawGame.dealerIndex < 0 || rawGame.dealerIndex >= playerNames.length) {
+                    throw new Error('Invalid currentGame.dealerIndex.');
+                }
+
+                const { totals, histories } = calculateScoresAndHistory(playerNames, rounds);
+                return {
+                    players: playerNames.map(name => ({ name, score: totals[name], scoreHistory: histories[name] })),
+                    rounds,
+                    dealerIndex: rawGame.dealerIndex,
+                };
+            }
+
+            function normalizeState(rawState) {
+                if (!rawState || typeof rawState !== 'object' || Array.isArray(rawState)) {
+                    throw new Error('Invalid file format: root value must be an object.');
+                }
+                if (!Array.isArray(rawState.players) || !Array.isArray(rawState.games)) {
+                    throw new Error("Invalid file format. Missing 'players' or 'games' array.");
+                }
+
+                const players = normalizePlayerNames(rawState.players, 'players', 0);
+                if (rawState.currentGame && players.length < 2) {
+                    throw new Error('Invalid currentGame: at least two players are required.');
+                }
+                return {
+                    schemaVersion: SCHEMA_VERSION,
+                    players,
+                    games: rawState.games.map(normalizeCompletedGame),
+                    currentGame: normalizeCurrentGame(rawState.currentGame, players),
+                };
+            }
 
             // --- MODALS ---
             const infoModal = document.getElementById('info-modal');
@@ -280,50 +453,70 @@
             const winnerOptionsEl = document.getElementById('winner-options');
             const dealerSelectionModal = document.getElementById('dealer-selection-modal');
             const dealerOptionsEl = document.getElementById('dealer-options');
-            
+
             let confirmCallback = null;
             let winnerSelectionCallback = null;
             let dealerSelectionCallback = null;
+            let previouslyFocusedElement = null;
+
+            function openModal(modal, focusSelector = 'button') {
+                previouslyFocusedElement = document.activeElement;
+                modal.inert = false;
+                modal.classList.add('active');
+                modal.setAttribute('aria-hidden', 'false');
+                requestAnimationFrame(() => modal.querySelector(focusSelector)?.focus());
+            }
+
+            function closeModal(modal) {
+                modal.classList.remove('active');
+                modal.setAttribute('aria-hidden', 'true');
+                modal.inert = true;
+                if (previouslyFocusedElement instanceof HTMLElement) previouslyFocusedElement.focus();
+                previouslyFocusedElement = null;
+            }
 
             function showInfoMessage(message) {
                 infoModalMessage.textContent = message;
-                infoModal.classList.add('active');
+                openModal(infoModal, '#info-modal-ok-btn');
             }
-            infoModalOkBtn.addEventListener('click', () => infoModal.classList.remove('active'));
+            infoModalOkBtn.addEventListener('click', () => closeModal(infoModal));
 
             function showConfirmation(title, message, onConfirm) {
                 modalTitle.textContent = title;
                 modalMessage.textContent = message;
                 confirmCallback = onConfirm;
-                confirmationModal.classList.add('active');
+                openModal(confirmationModal, '#modal-cancel-btn');
             }
 
             modalCancelBtn.addEventListener('click', () => {
-                confirmationModal.classList.remove('active');
+                closeModal(confirmationModal);
                 confirmCallback = null;
             });
 
             modalConfirmBtn.addEventListener('click', () => {
-                if (confirmCallback) confirmCallback();
-                confirmationModal.classList.remove('active');
+                const callback = confirmCallback;
                 confirmCallback = null;
+                closeModal(confirmationModal);
+                if (callback) callback();
             });
-            
+
             function showWinnerSelection(playersWithZero, onSelect) {
                 winnerOptionsEl.innerHTML = '';
                 winnerSelectionCallback = onSelect;
                 playersWithZero.forEach(playerName => {
                     const btn = document.createElement('button');
+                    btn.type = 'button';
                     btn.textContent = playerName;
                     btn.className = 'w-full text-left bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 p-3 rounded-lg hover:bg-blue-100';
                     btn.onclick = () => {
-                        winnerSelectionCallback(playerName);
-                        winnerSelectionModal.classList.remove('active');
+                        const callback = winnerSelectionCallback;
                         winnerSelectionCallback = null;
+                        closeModal(winnerSelectionModal);
+                        if (callback) callback(playerName);
                     };
                     winnerOptionsEl.appendChild(btn);
                 });
-                winnerSelectionModal.classList.add('active');
+                openModal(winnerSelectionModal);
             }
 
             function showDealerSelection(onSelect) {
@@ -331,17 +524,34 @@
                 dealerSelectionCallback = onSelect;
                 state.players.forEach((playerName, index) => {
                     const btn = document.createElement('button');
+                    btn.type = 'button';
                     btn.textContent = playerName;
                     btn.className = 'w-full text-left bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 p-3 rounded-lg hover:bg-blue-100';
                     btn.onclick = () => {
-                        dealerSelectionCallback(index);
-                        dealerSelectionModal.classList.remove('active');
+                        const callback = dealerSelectionCallback;
                         dealerSelectionCallback = null;
+                        closeModal(dealerSelectionModal);
+                        if (callback) callback(index);
                     };
                     dealerOptionsEl.appendChild(btn);
                 });
-                dealerSelectionModal.classList.add('active');
+                openModal(dealerSelectionModal);
             }
+
+            document.addEventListener('keydown', event => {
+                if (event.key !== 'Escape') return;
+                if (infoModal.classList.contains('active')) closeModal(infoModal);
+                else if (confirmationModal.classList.contains('active')) {
+                    confirmCallback = null;
+                    closeModal(confirmationModal);
+                } else if (winnerSelectionModal.classList.contains('active')) {
+                    winnerSelectionCallback = null;
+                    closeModal(winnerSelectionModal);
+                } else if (dealerSelectionModal.classList.contains('active')) {
+                    dealerSelectionCallback = null;
+                    closeModal(dealerSelectionModal);
+                }
+            });
 
 
             // --- CORE LOGIC ---
@@ -361,26 +571,30 @@
                     state.players.forEach((player, index) => {
                         const playerEl = document.createElement('div');
                         playerEl.className = 'player-item flex justify-between items-center bg-gray-100 dark:bg-gray-700 p-2 rounded-lg';
-                        playerEl.draggable = !isGameInProgress;
                         playerEl.dataset.index = index;
-                        
+
                         const contentWrapper = document.createElement('div');
                         contentWrapper.className = 'flex items-center';
 
                         if (!isGameInProgress) {
-                            const handle = document.createElement('span');
+                            const handle = document.createElement('button');
+                            handle.type = 'button';
                             handle.className = 'drag-handle';
+                            handle.draggable = true;
+                            handle.setAttribute('aria-label', `Reorder ${player}`);
                             handle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" /></svg>`;
                             contentWrapper.appendChild(handle);
                         }
-                        
+
                         const nameSpan = document.createElement('span');
                         nameSpan.textContent = player;
                         contentWrapper.appendChild(nameSpan);
-                        
+
                         const removeBtn = document.createElement('button');
+                        removeBtn.type = 'button';
                         removeBtn.dataset.index = index;
                         removeBtn.className = 'remove-player-btn text-red-500 hover:text-red-700';
+                        removeBtn.setAttribute('aria-label', `Remove ${player}`);
                         removeBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" /></svg>`;
                         if (isGameInProgress) {
                             removeBtn.classList.add('hidden');
@@ -396,14 +610,24 @@
 
             function addPlayer() {
                 const name = newPlayerNameInput.value.trim();
-                if (name && !state.players.includes(name)) {
-                    state.players.push(name);
-                    newPlayerNameInput.value = '';
-                    renderPlayers();
-                    saveStateToLocalStorage();
+                if (!name) {
+                    showInfoMessage('Enter a player name.');
+                    return;
                 }
+                if (name.length > MAX_PLAYER_NAME_LENGTH) {
+                    showInfoMessage(`Player names can contain at most ${MAX_PLAYER_NAME_LENGTH} characters.`);
+                    return;
+                }
+                if (state.players.some(player => player.localeCompare(name, undefined, { sensitivity: 'base' }) === 0)) {
+                    showInfoMessage('That player has already been added.');
+                    return;
+                }
+                state.players.push(name);
+                newPlayerNameInput.value = '';
+                renderPlayers();
+                saveStateToLocalStorage();
             }
-            
+
             function removePlayer(index) {
                 state.players.splice(index, 1);
                 renderPlayers();
@@ -432,11 +656,11 @@
                         proceed(dealerIndex);
                      });
                 }
-                
+
                 if (state.currentGame && state.currentGame.rounds.length > 0) {
                    showConfirmation(
-                       'Start New Game?', 
-                       'A game is already in progress. Starting a new one will discard its progress. Are you sure?', 
+                       'Start New Game?',
+                       'A game is already in progress. Starting a new one will discard its progress. Are you sure?',
                        startAction
                    );
                 } else {
@@ -449,16 +673,16 @@
                     gameAreaEl.classList.add('hidden');
                     return;
                 }
-                
+
                 gameStatusEl.style.display = 'block';
                 roundNumberEl.textContent = state.currentGame.rounds.length + 1;
                 currentDealerNameEl.textContent = state.currentGame.players[state.currentGame.dealerIndex].name;
-                
+
                 scoreboardEl.innerHTML = '';
                 state.currentGame.players.forEach((player, index) => {
                     const card = document.createElement('div');
                     card.className = `p-4 rounded-lg shadow-sm border dark:border-gray-700 transition-all duration-300 ${index === state.currentGame.dealerIndex ? 'dealer-highlight' : 'bg-gray-50 dark:bg-gray-700/50'}`;
-                    
+
                     const nameDiv = document.createElement('div');
                     nameDiv.className = 'text-lg font-semibold';
                     nameDiv.textContent = player.name;
@@ -466,43 +690,47 @@
                     const scoreDiv = document.createElement('div');
                     scoreDiv.className = 'text-4xl font-bold';
                     scoreDiv.textContent = player.score;
-                    
+
                     card.append(nameDiv, scoreDiv);
                     scoreboardEl.appendChild(card);
                 });
 
                 scoreEntryEl.innerHTML = '';
-                state.currentGame.players.forEach(player => {
+                state.currentGame.players.forEach((player, index) => {
                     const inputGroup = document.createElement('div');
-                    
+
                     const label = document.createElement('label');
                     label.className = 'block text-center font-medium mb-1';
                     label.textContent = player.name;
 
                     const input = document.createElement('input');
                     input.type = 'number';
+                    input.id = `score-player-${index}`;
+                    label.htmlFor = input.id;
                     input.dataset.player = player.name;
                     input.className = 'score-input w-full p-2 border dark:border-gray-600 rounded-lg text-center bg-transparent';
                     input.min = '0';
+                    input.step = '1';
+                    input.inputMode = 'numeric';
 
                     inputGroup.append(label, input);
                     scoreEntryEl.appendChild(inputGroup);
                 });
-                
+
                 undoRoundBtn.disabled = state.currentGame.rounds.length === 0;
                 updateScoreProgressionChart();
             }
 
             function addRound() {
                 const inputs = [...scoreEntryEl.querySelectorAll('.score-input')];
-                const scores = {};
+                const scores = createDictionary();
                 let validationError = '';
                 let playersWithZero = [];
 
                 inputs.forEach(input => {
                     const playerName = input.dataset.player;
-                    const score = parseInt(input.value);
-                    if (isNaN(score) || score < 0) validationError = 'All scores must be a number of 0 or greater.';
+                    const score = input.value.trim() === '' ? Number.NaN : Number(input.value);
+                    if (!isValidScore(score)) validationError = 'All scores must be non-negative whole numbers.';
                     scores[playerName] = score;
                     if (score === 0) playersWithZero.push(playerName);
                 });
@@ -516,16 +744,16 @@
                     return;
                 }
                 scoreEntryErrorEl.textContent = '';
-                
+
                 const processRound = (winner) => {
                     const round = { winner, scores };
                     state.currentGame.rounds.push(round);
-                    
+
                     state.currentGame.players.forEach(player => {
                         player.score += scores[player.name];
                         player.scoreHistory.push(player.score);
                     });
-                    
+
                     const playersOver500 = state.currentGame.players.filter(p => p.score >= 500);
                     if (playersOver500.length > 0) {
                         endGame();
@@ -539,7 +767,7 @@
                     }
                     saveStateToLocalStorage();
                 };
-                
+
                 if (playersWithZero.length > 1) {
                     showWinnerSelection(playersWithZero, processRound);
                 } else {
@@ -549,16 +777,16 @@
 
             function undoLastRound() {
                 if (!state.currentGame || state.currentGame.rounds.length === 0) return;
-                
+
                 state.currentGame.rounds.pop();
-                
+
                 state.currentGame.players.forEach(player => {
                     player.scoreHistory.pop();
                     player.score = player.scoreHistory[player.scoreHistory.length - 1];
                 });
-                
+
                 state.currentGame.dealerIndex = (state.currentGame.dealerIndex - 1 + state.currentGame.players.length) % state.currentGame.players.length;
-                
+
                 renderGame();
                 saveStateToLocalStorage();
             }
@@ -575,7 +803,7 @@
                     finalScores: state.currentGame.players.map(p => ({name: p.name, score: p.score})),
                     rounds: state.currentGame.rounds
                 });
-                
+
                 gameStatusEl.innerHTML = '';
                 const winnerDiv = document.createElement('div');
                 winnerDiv.className = 'text-2xl font-bold text-green-600 dark:text-green-400 p-4 bg-green-100 dark:bg-green-900/50 rounded-lg text-center fade-in';
@@ -589,7 +817,7 @@
                  state.currentGame.players.forEach((player) => {
                     const card = document.createElement('div');
                     card.className = `p-4 rounded-lg shadow-sm border bg-gray-50 dark:bg-gray-700/50 dark:border-gray-700`;
-                    
+
                     const nameDiv = document.createElement('div');
                     nameDiv.className = 'text-lg font-semibold';
                     nameDiv.textContent = player.name;
@@ -597,7 +825,7 @@
                     const scoreDiv = document.createElement('div');
                     scoreDiv.className = 'text-4xl font-bold';
                     scoreDiv.textContent = player.score;
-                    
+
                     card.append(nameDiv, scoreDiv);
                     scoreboardEl.appendChild(card);
                 });
@@ -606,9 +834,9 @@
                     const playerName = state.currentGame.players[index].name;
                     if (winners.includes(playerName)) card.classList.add('winner-highlight');
                 });
-                
+
                 state.currentGame = null;
-                
+
                 renderPlayers();
                 if (!statsSectionEl.classList.contains('hidden')) calculateAndDisplayStats();
                 saveStateToLocalStorage();
@@ -617,16 +845,43 @@
 
             // --- DATA & STATE MANAGEMENT ---
             function saveStateToLocalStorage() {
-                localStorage.setItem('unoTrackerState', JSON.stringify(state));
+                state.schemaVersion = SCHEMA_VERSION;
+                try {
+                    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+                    return true;
+                } catch (error) {
+                    console.error('Unable to save game state:', error);
+                    showInfoMessage('The game could not be saved in this browser. Export your data to avoid losing it.');
+                    return false;
+                }
             }
 
             function loadStateFromLocalStorage() {
-                const savedState = localStorage.getItem('unoTrackerState');
+                let savedState;
+                try {
+                    savedState = localStorage.getItem(STORAGE_KEY);
+                } catch (error) {
+                    console.error('Unable to access browser storage:', error);
+                    showInfoMessage('Browser storage is unavailable. Export your data before closing this page.');
+                    return;
+                }
                 if (savedState) {
-                    state = JSON.parse(savedState);
+                    try {
+                        state = normalizeState(JSON.parse(savedState));
+                    } catch (error) {
+                        console.error('Invalid saved state:', error);
+                        try {
+                            localStorage.setItem(INVALID_STORAGE_BACKUP_KEY, savedState);
+                        } catch (backupError) {
+                            console.error('Unable to preserve invalid saved state:', backupError);
+                        }
+                        localStorage.removeItem(STORAGE_KEY);
+                        state = createEmptyState();
+                        showInfoMessage('Saved data was invalid and could not be loaded. A recovery copy was preserved in this browser.');
+                    }
                 }
             }
-            
+
             function updateControlButtonsState() {
                 const hasData = state.players.length > 0 || state.games.length > 0;
                 exportDataBtn.disabled = !hasData;
@@ -649,17 +904,19 @@
             }
 
             function importData(event) {
-                 const file = event.target.files[0];
+                const file = event.target.files[0];
                 if (!file) return;
+                if (file.size > 2 * 1024 * 1024) {
+                    showInfoMessage('The import file is too large. The maximum size is 2 MB.');
+                    importDataInput.value = '';
+                    return;
+                }
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
                     try {
-                        const importedState = JSON.parse(e.target.result);
-                        if (!importedState.players || !Array.isArray(importedState.players) || !importedState.games || !Array.isArray(importedState.games)) {
-                            throw new Error("Invalid file format. Missing 'players' or 'games' array.");
-                        }
-                        
+                        const importedState = normalizeState(JSON.parse(e.target.result));
+
                         const importAction = () => {
                             state = importedState;
                             if(!state.currentGame) state.currentGame = null;
@@ -676,9 +933,9 @@
                             showInfoMessage("Data imported successfully!");
                         };
 
-                        if (state.currentGame || (state.games.length > 0 && state.players.length > 0)) {
+                        if (state.currentGame || state.games.length > 0 || state.players.length > 0) {
                             showConfirmation(
-                                'Import Data?', 
+                                'Import Data?',
                                 'This will overwrite all current session data. Are you sure you want to proceed?',
                                 importAction
                             );
@@ -692,6 +949,10 @@
                         importDataInput.value = '';
                     }
                 };
+                reader.onerror = () => {
+                    showInfoMessage('The selected file could not be read.');
+                    importDataInput.value = '';
+                };
                 reader.readAsText(file);
             }
 
@@ -702,7 +963,7 @@
                     <div class="flex flex-wrap gap-4 justify-center mb-6">
                         <select id="stats-player-filter" class="p-2 border rounded-lg bg-transparent dark:border-gray-600"><option value="all">All Players</option></select>
                         <input type="date" id="stats-date-filter" class="p-2 border rounded-lg bg-transparent dark:border-gray-600">
-                        <button id="clear-filters-btn" class="bg-gray-300 dark:bg-gray-600 px-4 py-2 rounded-lg">Clear Filters</button>
+                        <button id="clear-filters-btn" type="button" class="bg-gray-300 dark:bg-gray-600 px-4 py-2 rounded-lg">Clear Filters</button>
                     </div>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
@@ -722,26 +983,37 @@
                         <h3 class="text-xl font-semibold mb-3">Game History</h3>
                         <div id="game-history" class="space-y-6"></div>
                     </div>`;
-                
-                document.getElementById('stats-player-filter').addEventListener('change', calculateAndDisplayStats);
-                document.getElementById('stats-date-filter').addEventListener('change', calculateAndDisplayStats);
+
+                document.getElementById('stats-player-filter').addEventListener('change', event => {
+                    statsFilters.player = event.currentTarget.value;
+                    calculateAndDisplayStats();
+                });
+                document.getElementById('stats-date-filter').addEventListener('change', event => {
+                    statsFilters.date = event.currentTarget.value;
+                    calculateAndDisplayStats();
+                });
                 document.getElementById('clear-filters-btn').addEventListener('click', () => {
-                    document.getElementById('stats-player-filter').value = 'all';
-                    document.getElementById('stats-date-filter').value = '';
+                    statsFilters = { player: 'all', date: '' };
                     calculateAndDisplayStats();
                 });
             }
 
+            function getLocalDateKey(dateValue) {
+                const date = new Date(dateValue);
+                if (Number.isNaN(date.getTime())) return '';
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
+            }
+
             function getFilteredGames() {
-                const selectedPlayer = document.getElementById('stats-player-filter').value;
-                const selectedDate = document.getElementById('stats-date-filter').value;
-                
                 let filtered = state.games;
-                if (selectedPlayer !== 'all') {
-                    filtered = filtered.filter(game => game.players.includes(selectedPlayer));
+                if (statsFilters.player !== 'all') {
+                    filtered = filtered.filter(game => game.players.includes(statsFilters.player));
                 }
-                if (selectedDate) {
-                    filtered = filtered.filter(game => game.date.startsWith(selectedDate));
+                if (statsFilters.date) {
+                    filtered = filtered.filter(game => getLocalDateKey(game.date) === statsFilters.date);
                 }
                 return filtered;
             }
@@ -751,30 +1023,31 @@
                     statsSectionEl.innerHTML = '<h2 class="text-3xl font-bold mb-6 text-center">No completed games to show statistics for.</h2>';
                     return;
                 }
-                
+
                 renderStatsSkeleton();
 
-                const filteredGames = getFilteredGames();
                 const allPlayers = new Set();
                 state.games.forEach(g => g.players.forEach(p => allPlayers.add(p)));
 
                 const playerFilter = document.getElementById('stats-player-filter');
-                const currentSelection = playerFilter.value;
                 playerFilter.innerHTML = '<option value="all">All Players</option>';
                 allPlayers.forEach(player => {
                     const option = document.createElement('option');
-                    option.value = escape(player);
-                    option.textContent = escape(player);
+                    option.value = player;
+                    option.textContent = player;
                     playerFilter.appendChild(option);
                 });
-                 if (allPlayers.has(currentSelection)) playerFilter.value = currentSelection;
+                if (!allPlayers.has(statsFilters.player)) statsFilters.player = 'all';
+                playerFilter.value = statsFilters.player;
+                document.getElementById('stats-date-filter').value = statsFilters.date;
 
-                const winCounts = {};
+                const filteredGames = getFilteredGames();
+                const winCounts = createDictionary();
                 allPlayers.forEach(p => { winCounts[p] = 0; });
                 filteredGames.forEach(game => game.winners.forEach(winner => { if(winCounts[winner] !== undefined) winCounts[winner]++; }));
 
-                const allRounds = filteredGames.flatMap(game => 
-                    game.rounds.flatMap((round, roundIndex) => 
+                const allRounds = filteredGames.flatMap(game =>
+                    game.rounds.flatMap((round, roundIndex) =>
                         Object.entries(round.scores).map(([player, score]) => ({player, score}))
                     )
                 );
@@ -789,21 +1062,23 @@
             }
 
             function calculateAllTimeStats(allGames, allPlayers) {
-                const winStreaks = {};
-                const h2h = {};
+                const winStreaks = createDictionary();
+                const h2h = createDictionary();
                 allPlayers.forEach(p1 => {
                     winStreaks[p1] = { current: 0, max: 0 };
-                    h2h[p1] = {};
+                    h2h[p1] = createDictionary();
                     allPlayers.forEach(p2 => { if (p1 !== p2) h2h[p1][p2] = { win: 0, loss: 0 }; });
                 });
-                
-                allGames.forEach(game => {
+
+                [...allGames].sort((a, b) => new Date(a.date) - new Date(b.date)).forEach(game => {
                     allPlayers.forEach(player => {
                         if (game.players.includes(player)) {
                            if (game.winners.includes(player)) {
                                 winStreaks[player].current++;
                                 if (winStreaks[player].current > winStreaks[player].max) winStreaks[player].max = winStreaks[player].current;
-                                game.players.forEach(op => { if(player !== op) h2h[player][op].win++; });
+                                game.players.forEach(op => {
+                                    if (player !== op && !game.winners.includes(op)) h2h[player][op].win++;
+                                });
                             } else {
                                 winStreaks[player].current = 0;
                                 game.winners.forEach(winner => { if(h2h[player][winner]) h2h[player][winner].loss++; });
@@ -812,8 +1087,8 @@
                     });
                 });
 
-                const maxStreak = Object.entries(winStreaks).reduce((max, [player, data]) => 
-                    data.max > max.streak ? { player, streak: data.max } : max, 
+                const maxStreak = Object.entries(winStreaks).reduce((max, [player, data]) =>
+                    data.max > max.streak ? { player, streak: data.max } : max,
                     {player: 'N/A', streak: 0}
                 );
                 return { maxStreak, h2h };
@@ -828,7 +1103,7 @@
                     <ul class="list-disc pl-5">${rounds.map(r => `<li>${escape(r.player)}: ${r.score} points</li>`).join('') || '<li>N/A</li>'}</ul>
                     <p class="mt-2"><strong>Longest Win Streak (all time):</strong> ${escape(streak.player)} (${streak.streak} games)</p>`;
             }
-            
+
             function renderH2HStats(element, h2h) {
                 element.innerHTML = Object.entries(h2h).map(([p1, op]) => `
                     <div class="mb-2"><strong>${escape(p1)} vs:</strong><ul class="list-disc pl-5 text-sm">${Object.entries(op).map(([p2, r]) => `<li>${escape(p2)}: ${r.win}W - ${r.loss}L</li>`).join('')}</ul></div>
@@ -840,21 +1115,21 @@
                      element.innerHTML = '<p>No games match the current filters.</p>';
                      return;
                  }
-                const gamesByDate = games.reduce((acc, game) => {
-                    const date = new Date(game.date).toLocaleDateString('en-US');
+                const gamesByDate = [...games].sort((a, b) => new Date(b.date) - new Date(a.date)).reduce((acc, game) => {
+                    const date = new Date(game.date).toLocaleDateString();
                     if (!acc[date]) acc[date] = [];
                     acc[date].push(game);
                     return acc;
-                }, {});
-                
-                element.innerHTML = Object.entries(gamesByDate).reverse().map(([date, dateGames]) => `
+                }, createDictionary());
+
+                element.innerHTML = Object.entries(gamesByDate).map(([date, dateGames]) => `
                     <h4 class="text-lg font-semibold mt-4 border-b dark:border-gray-600 pb-1">Games on ${escape(date)}</h4>
                     ${dateGames.map((game, index) => `
                         <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg mt-2">
                             <details>
                                 <summary class="cursor-pointer font-medium">Game ${index + 1}: Winner - ${escape(game.winners.join(', '))}</summary>
                                 <div class="mt-4">
-                                    <p><strong>Final Scores:</strong> ${game.finalScores.map(s => `${escape(s.name)} (${s.score})`).join(', ')}</p>
+                                    <p><strong>Final Scores:</strong> ${game.finalScores.map(s => `${escape(s.name)} (${escape(s.score)})`).join(', ')}</p>
                                     <h5 class="font-semibold mt-3 mb-1">Round Details:</h5>
                                     <div class="overflow-x-auto">
                                         <table class="w-full text-center border-collapse dark:border-gray-600">
@@ -866,7 +1141,7 @@
                                             ${game.rounds.map((round, i) => `
                                                 <tr>
                                                     <td class="py-2 px-3 border dark:border-gray-600">${i + 1}</td>
-                                                    ${game.players.map(p => `<td class="py-2 px-3 border dark:border-gray-600 ${round.winner === p ? 'round-winner' : ''}">${round.scores[p] !== undefined ? round.scores[p] : 'N/A'}</td>`).join('')}
+                                                    ${game.players.map(p => `<td class="py-2 px-3 border dark:border-gray-600 ${round.winner === p ? 'round-winner' : ''}">${Object.prototype.hasOwnProperty.call(round.scores, p) ? escape(round.scores[p]) : 'N/A'}</td>`).join('')}
                                                 </tr>`).join('')}
                                             </tbody>
                                         </table>
@@ -877,7 +1152,7 @@
                     `).join('')}
                 `).join('');
             }
-            
+
             // --- CHART RENDERING (WITH DARK MODE SUPPORT) ---
             function getChartThemeColors() {
                 const isDarkMode = document.documentElement.classList.contains('dark');
@@ -890,11 +1165,16 @@
             function updateWinsChart(sortedWins) {
                 if (winsBarChart) winsBarChart.destroy();
                 const container = document.getElementById('wins-bar-chart-container');
+                if (!container) return;
+                if (typeof window.Chart === 'undefined') {
+                    container.innerHTML = '<p class="text-sm text-gray-500 text-center">Chart unavailable while the chart library is offline.</p>';
+                    return;
+                }
                 container.innerHTML = '<canvas id="wins-bar-chart"></canvas>';
                 const ctx = document.getElementById('wins-bar-chart').getContext('2d');
                 const themeColors = getChartThemeColors();
-                
-                winsBarChart = new Chart(ctx, {
+
+                winsBarChart = new window.Chart(ctx, {
                     type: 'bar',
                     data: {
                         labels: sortedWins.map(item => item[0]),
@@ -906,11 +1186,11 @@
                             borderWidth: 1
                         }]
                     },
-                    options: { 
+                    options: {
                         responsive: true, maintainAspectRatio: false,
-                        scales: { 
-                            y: { 
-                                beginAtZero: true, 
+                        scales: {
+                            y: {
+                                beginAtZero: true,
                                 ticks: { stepSize: 1, color: themeColors.textColor },
                                 grid: { color: themeColors.gridColor }
                             },
@@ -925,10 +1205,15 @@
                     }
                 });
             }
-            
+
             function updateScoreProgressionChart() {
                 if (scoreProgressionChart) scoreProgressionChart.destroy();
-                const container = document.getElementById('score-progression-chart').parentElement;
+                const container = document.getElementById('score-progression-chart-container');
+                if (!container) return;
+                if (typeof window.Chart === 'undefined') {
+                    container.innerHTML = '<p class="text-sm text-gray-500 text-center">Chart unavailable while the chart library is offline.</p>';
+                    return;
+                }
                 container.innerHTML = '<canvas id="score-progression-chart"></canvas>';
                 const chartCanvas = document.getElementById('score-progression-chart');
 
@@ -937,7 +1222,7 @@
                     return;
                 }
                 chartCanvas.style.display = 'block';
-                
+
                 const themeColors = getChartThemeColors();
                 const colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
                 const datasets = state.currentGame.players.map((player, index) => ({
@@ -949,16 +1234,16 @@
                 }));
                 const labels = Array.from({ length: state.currentGame.rounds.length + 1 }, (_, i) => `R ${i}`);
 
-                scoreProgressionChart = new Chart(chartCanvas, {
+                scoreProgressionChart = new window.Chart(chartCanvas, {
                     type: 'line', data: { labels, datasets },
-                    options: { 
-                        responsive: true, 
-                        plugins: { 
-                            legend: { position: 'top', labels: { color: themeColors.textColor } }, 
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { position: 'top', labels: { color: themeColors.textColor } },
                             title: { display: true, text: 'Score Progression', color: themeColors.textColor }
-                        }, 
-                        scales: { 
-                            y: { 
+                        },
+                        scales: {
+                            y: {
                                 beginAtZero: true,
                                 ticks: { color: themeColors.textColor },
                                 grid: { color: themeColors.gridColor }
@@ -976,11 +1261,24 @@
             // --- EVENT LISTENERS ---
             addPlayerBtn.addEventListener('click', addPlayer);
             newPlayerNameInput.addEventListener('keyup', (e) => { if (e.key === 'Enter') addPlayer(); });
-            playerListEl.addEventListener('click', (e) => { 
+            playerListEl.addEventListener('click', (e) => {
                 const removeButton = e.target.closest('.remove-player-btn');
                 if(removeButton) {
                     removePlayer(parseInt(removeButton.dataset.index));
                 }
+            });
+            playerListEl.addEventListener('keydown', event => {
+                const handle = event.target.closest('.drag-handle');
+                if (!handle || !['ArrowUp', 'ArrowDown'].includes(event.key)) return;
+                const playerItem = handle.closest('.player-item');
+                const index = Number(playerItem.dataset.index);
+                const targetIndex = event.key === 'ArrowUp' ? index - 1 : index + 1;
+                if (targetIndex < 0 || targetIndex >= state.players.length) return;
+                event.preventDefault();
+                [state.players[index], state.players[targetIndex]] = [state.players[targetIndex], state.players[index]];
+                saveStateToLocalStorage();
+                renderPlayers();
+                requestAnimationFrame(() => playerListEl.querySelector(`[data-index="${targetIndex}"] .drag-handle`)?.focus());
             });
             newGameBtn.addEventListener('click', startNewGame);
             addRoundBtn.addEventListener('click', addRound);
@@ -1036,7 +1334,7 @@
                     const dropIndex = parseInt(dropTarget.dataset.index);
                     const [removed] = state.players.splice(dragStartIndex, 1);
                     state.players.splice(dropIndex, 0, removed);
-                    
+
                     saveStateToLocalStorage();
                     renderPlayers();
                 }
@@ -1067,10 +1365,10 @@
                 const touch = e.touches[0];
                 const elementUnderTouch = document.elementFromPoint(touch.clientX, touch.clientY);
                 const dropTarget = elementUnderTouch ? elementUnderTouch.closest('.player-item') : null;
-                
+
                 // Clear previous drop targets
                 document.querySelectorAll('.player-item').forEach(item => item.classList.remove('drag-over-target'));
-                
+
                 if (dropTarget && dropTarget !== draggedItem) {
                     dropTarget.classList.add('drag-over-target');
                 }
@@ -1083,7 +1381,7 @@
                 const touch = e.changedTouches[0];
                 const elementUnderTouch = document.elementFromPoint(touch.clientX, touch.clientY);
                 let dropTarget = elementUnderTouch ? elementUnderTouch.closest('.player-item') : null;
-                
+
                 // If dropTarget is null (e.g., finger lifted outside the list), try to find the last highlighted target
                 if (!dropTarget) {
                     dropTarget = playerListEl.querySelector('.drag-over-target');
@@ -1095,14 +1393,20 @@
                         // Reorder the players array
                         const [removed] = state.players.splice(dragStartIndex, 1);
                         state.players.splice(dropIndex, 0, removed);
-                        
+
                         saveStateToLocalStorage();
                         renderPlayers(); // Re-render to reflect the new order
                     }
                 }
-                
+
                 // Cleanup styles
                 draggedItem.classList.remove('dragging');
+                document.querySelectorAll('.player-item').forEach(item => item.classList.remove('drag-over-target'));
+                draggedItem = null;
+            });
+
+            playerListEl.addEventListener('touchcancel', () => {
+                if (draggedItem) draggedItem.classList.remove('dragging');
                 document.querySelectorAll('.player-item').forEach(item => item.classList.remove('drag-over-target'));
                 draggedItem = null;
             });
@@ -1118,7 +1422,12 @@
             updateControlButtonsState();
 
             // Initialize theme on load
-            const savedTheme = localStorage.getItem('theme');
+            let savedTheme = null;
+            try {
+                savedTheme = localStorage.getItem('theme');
+            } catch (error) {
+                console.error('Unable to load theme preference:', error);
+            }
             const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             if (savedTheme) {
                 setTheme(savedTheme);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1554 @@
+{
+  "name": "uno-game-tracker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uno-game-tracker",
+      "version": "1.0.0",
+      "devDependencies": {
+        "html-validate": "^9.7.1",
+        "jsdom": "^24.1.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@html-validate/stylish": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-4.3.0.tgz",
+      "integrity": "sha512-eUfvKpRJg5TvzSfTf2EovrQoTKjkRnPUOUnXVJ2cQ4GbC/bQw98oxN+DdSf+HxOBK00YOhsP52xWdJPV1o4n5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-4.0.0.tgz",
+      "integrity": "sha512-rLZQkN6IfNwG6iqZZwqFMcs7DvQX3ZrLVhsHmSO1LUA4EZAz+VZLpTBCIOFsC5Qu3xuwzVfRMZ+1rtk/mCRRZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "kleur": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "ajv": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-validate": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-9.7.1.tgz",
+      "integrity": "sha512-sOCmfMGrSwax20SG2s+4iC8WqsE7JqncN6kh+YFwrb/gvP2VYN8WEnD4PIrnKBIeRf9ju8BGi50NdpHx9UNS9w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/html-validate"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@html-validate/stylish": "^4.1.0",
+        "@sidvind/better-ajv-errors": "4.0.0",
+        "ajv": "^8.0.0",
+        "glob": "^10.0.0",
+        "kleur": "^4.1.0",
+        "minimist": "^1.2.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.mjs"
+      },
+      "engines": {
+        "node": "^18.19.0 || >= 20.6.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.1 || ^28.1.3 || ^29.0.3 || ^30.0.0",
+        "jest-diff": "^27.1 || ^28.1.3 || ^29.0.3 || ^30.0.0",
+        "jest-snapshot": "^27.1 || ^28.1.3 || ^29.0.3 || ^30.0.0",
+        "vitest": "^0.34.0 || ^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "jest-diff": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "uno-game-tracker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test tests/app.test.cjs",
+    "validate:html": "html-validate index.html",
+    "check": "npm run validate:html && npm test"
+  },
+  "devDependencies": {
+    "html-validate": "^9.7.1",
+    "jsdom": "^24.1.3"
+  }
+}

--- a/tests/app.test.cjs
+++ b/tests/app.test.cjs
@@ -1,0 +1,179 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { JSDOM, VirtualConsole } = require('jsdom');
+
+const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+
+async function createApp(savedState) {
+  const errors = [];
+  const virtualConsole = new VirtualConsole();
+  virtualConsole.on('jsdomError', error => errors.push(error));
+
+  const dom = new JSDOM(html, {
+    url: 'https://uno.test/',
+    runScripts: 'dangerously',
+    pretendToBeVisual: true,
+    virtualConsole,
+    beforeParse(window) {
+      window.matchMedia = () => ({
+        matches: false,
+        addEventListener() {},
+        removeEventListener() {},
+      });
+      if (savedState !== undefined) {
+        window.localStorage.setItem('unoTrackerState', savedState);
+      }
+    },
+  });
+
+  await new Promise(resolve => dom.window.addEventListener('load', () => setTimeout(resolve, 0)));
+  return { dom, window: dom.window, document: dom.window.document, errors };
+}
+
+function click(app, element) {
+  element.dispatchEvent(new app.window.MouseEvent('click', { bubbles: true }));
+}
+
+function change(app, element) {
+  element.dispatchEvent(new app.window.Event('change', { bubbles: true }));
+}
+
+function addPlayer(app, name) {
+  app.document.querySelector('#new-player-name').value = name;
+  click(app, app.document.querySelector('#add-player-btn'));
+}
+
+function startGame(app) {
+  click(app, app.document.querySelector('#new-game-btn'));
+  click(app, app.document.querySelector('#dealer-options button'));
+}
+
+test('validates whole-number scores and preserves statistics filters', async t => {
+  const app = await createApp();
+  t.after(() => app.dom.window.close());
+
+  addPlayer(app, 'Alice');
+  addPlayer(app, 'A&B');
+  startGame(app);
+
+  let inputs = app.document.querySelectorAll('.score-input');
+  inputs[0].value = '0';
+  inputs[1].value = '1.5';
+  click(app, app.document.querySelector('#add-round-btn'));
+  assert.match(app.document.querySelector('#score-entry-error').textContent, /whole numbers/);
+  assert.equal(app.document.querySelector('#round-number').textContent, '1');
+
+  inputs[1].value = '500';
+  click(app, app.document.querySelector('#add-round-btn'));
+  click(app, app.document.querySelector('#toggle-stats-btn'));
+
+  const specialNameOption = [...app.document.querySelectorAll('#stats-player-filter option')]
+    .find(option => option.value === 'A&B');
+  assert.equal(specialNameOption.textContent, 'A&B');
+
+  let playerFilter = app.document.querySelector('#stats-player-filter');
+  playerFilter.value = 'A&B';
+  change(app, playerFilter);
+  playerFilter = app.document.querySelector('#stats-player-filter');
+  assert.equal(playerFilter.value, 'A&B');
+  assert.match(app.document.querySelector('#overall-stats').textContent, /Total Games Played \(in filter\): 1/);
+
+  const saved = JSON.parse(app.window.localStorage.getItem('unoTrackerState'));
+  assert.equal(saved.schemaVersion, 1);
+  const gameDate = new Date(saved.games[0].date);
+  const dateKey = [
+    gameDate.getFullYear(),
+    String(gameDate.getMonth() + 1).padStart(2, '0'),
+    String(gameDate.getDate()).padStart(2, '0'),
+  ].join('-');
+
+  let dateFilter = app.document.querySelector('#stats-date-filter');
+  dateFilter.value = dateKey;
+  change(app, dateFilter);
+  dateFilter = app.document.querySelector('#stats-date-filter');
+  assert.equal(dateFilter.value, dateKey);
+  assert.deepEqual(app.errors, []);
+});
+
+test('handles a __proto__ player name without corrupting scores', async t => {
+  const app = await createApp();
+  t.after(() => app.dom.window.close());
+
+  addPlayer(app, '__proto__');
+  addPlayer(app, 'Bob');
+  startGame(app);
+  const inputs = app.document.querySelectorAll('.score-input');
+  inputs[0].value = '0';
+  inputs[1].value = '500';
+  click(app, app.document.querySelector('#add-round-btn'));
+
+  const saved = JSON.parse(app.window.localStorage.getItem('unoTrackerState'));
+  assert.equal(saved.games[0].rounds[0].scores.__proto__, 0);
+  assert.equal(saved.games[0].finalScores[0].score, 0);
+  assert.deepEqual(app.errors, []);
+});
+
+test('migrates a one-player state and recovers from invalid storage', async t => {
+  const onePlayerState = JSON.stringify({ players: ['Solo'], games: [], currentGame: null });
+  const onePlayerApp = await createApp(onePlayerState);
+  t.after(() => onePlayerApp.dom.window.close());
+  assert.match(onePlayerApp.document.querySelector('#player-list').textContent, /Solo/);
+
+  const invalidApp = await createApp('{broken json');
+  t.after(() => invalidApp.dom.window.close());
+  assert.match(invalidApp.document.querySelector('#info-modal-message').textContent, /Saved data was invalid/);
+  assert.equal(invalidApp.window.localStorage.getItem('unoTrackerState'), null);
+  assert.equal(invalidApp.window.localStorage.getItem('unoTrackerStateInvalidBackup'), '{broken json');
+  assert.deepEqual(invalidApp.errors, []);
+});
+
+test('does not count co-winners as head-to-head wins', async t => {
+  const app = await createApp();
+  t.after(() => app.dom.window.close());
+
+  ['Alice', 'Bob', 'Charlie'].forEach(name => addPlayer(app, name));
+  startGame(app);
+  const inputs = app.document.querySelectorAll('.score-input');
+  inputs[0].value = '0';
+  inputs[1].value = '0';
+  inputs[2].value = '500';
+  click(app, app.document.querySelector('#add-round-btn'));
+  click(app, app.document.querySelector('#winner-options button'));
+  click(app, app.document.querySelector('#toggle-stats-btn'));
+
+  const aliceStats = [...app.document.querySelectorAll('#h2h-stats > div')]
+    .find(element => element.querySelector('strong').textContent.startsWith('Alice'));
+  assert.match(aliceStats.textContent, /Bob: 0W - 0L/);
+});
+
+test('normalizes imported totals instead of rendering imported HTML', async t => {
+  const app = await createApp();
+  t.after(() => app.dom.window.close());
+
+  const payload = {
+    players: ['Alice', 'Bob'],
+    games: [{
+      date: new Date().toISOString(),
+      players: ['Alice', 'Bob'],
+      winners: ['Alice'],
+      finalScores: [
+        { name: 'Alice', score: '<img src=x onerror=alert(1)>' },
+        { name: 'Bob', score: 500 },
+      ],
+      rounds: [{ winner: 'Alice', scores: { Alice: 0, Bob: 500 } }],
+    }],
+    currentGame: null,
+  };
+  const file = new app.window.File([JSON.stringify(payload)], 'scores.json', { type: 'application/json' });
+  const input = app.document.querySelector('#import-data-input');
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  change(app, input);
+  await new Promise(resolve => setTimeout(resolve, 20));
+
+  assert.equal(app.document.querySelectorAll('img').length, 0);
+  const imported = JSON.parse(app.window.localStorage.getItem('unoTrackerState'));
+  assert.equal(imported.games[0].finalScores[0].score, 0);
+  assert.equal(typeof imported.games[0].finalScores[0].score, 'number');
+});


### PR DESCRIPTION
## Summary

- preserve player and date filters when statistics are recalculated
- validate, normalize, and version imported and browser-stored data
- prevent imported HTML and special player names from corrupting scores
- require non-negative whole-number scores
- handle co-winners correctly in head-to-head statistics
- use local dates for filtering and chronological ordering for streaks/history
- improve modal, form, drag-and-drop, and keyboard accessibility
- pin CDN dependency versions and degrade gracefully when Chart.js is unavailable
- correct README instructions and add repeatable validation/tests

## Verification

- `npm run check`
  - HTML validation passes
  - 5 DOM integration tests pass
- `npm audit --audit-level=high`: 0 vulnerabilities

The tests cover statistics filters, integer validation, `__proto__` player names, legacy and corrupt storage, co-winner head-to-head results, and sanitized JSON imports.